### PR TITLE
Fix for Bug #20, uses Protobuf FieldDescriptor->name()

### DIFF
--- a/protobuf_for_node.cc
+++ b/protobuf_for_node.cc
@@ -143,11 +143,11 @@ namespace protobuf_for_node {
           from <<
             "var x = arr[" << i << "]; "
             "if(x !== undefined) this['" <<
-            descriptor->field(i)->camelcase_name() <<
+            descriptor->field(i)->name() <<
             "'] = x; ";
 
           if (i > 0) to << ", ";
-          to << "this['" << descriptor->field(i)->camelcase_name() << "']";
+          to << "this['" << descriptor->field(i)->name() << "']";
         }
 
         from << " }})";


### PR DESCRIPTION
Getter and setter functions changed from using FieldDescriptor->camelcase_name() to FieldDescriptor->name()

Allows for protobuf field names with underscores to be used.
