### PR TITLE
Fix compilations for macos mountain lion

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -6,6 +6,17 @@
 			"dependencies": ["protobuf/protobuf.gyp:protobuf_full_do_not_use"],
 			"sources": [
 				"protobuf_for_node.cc", "addon.cc"
+			],
+			'conditions': [
+				[
+					'OS =="mac"',{
+						'xcode_settings':{
+						  'OTHER_CFLAGS' : [
+							'-mmacosx-version-min=10.7'
+						  ]
+						}
+			  		}
+				]
 			]
 		}
 	]


### PR DESCRIPTION
Protobuf does not compile on MacOs Mountain lion anymore. 

The changes fixes this issue. I could not test with older versions of MacOS so i cannot guarantee it works for those
