### PR TITLE
Use Number present uint64 and int64, when they are safe numbers (-2^53 < n < 2^53)

### DIFF
--- a/protobuf_for_node.cc
+++ b/protobuf_for_node.cc
@@ -204,14 +204,24 @@ namespace protobuf_for_node {
         case FieldDescriptor::CPPTYPE_UINT32:
           return Integer::NewFromUnsigned(GET(UInt32));
         case FieldDescriptor::CPPTYPE_INT64: {
+          int64_t value = GET(Int64);
+          if (value >= MIN_SAFE_INTEGER && value <= MAX_SAFE_INTEGER) {
+            return Number::New(value);
+          }
+          // use string instead
           std::ostringstream ss;
-          ss << GET(Int64);
+          ss << value;
           string s = ss.str();
           return String::New(s.data(), s.length());
         }
         case FieldDescriptor::CPPTYPE_UINT64: {
+          uint64_t value = GET(UInt64);
+          if (value >= MIN_SAFE_UNSIGNED_INTEGER && value <= MAX_SAFE_UNSIGNED_INTEGER) {
+            return Number::New(value);
+          }
+          // use string instead
           std::ostringstream ss;
-          ss << GET(UInt64);
+          ss << value;
           string s = ss.str();
           return String::New(s.data(), s.length());
         }

--- a/protobuf_for_node.h
+++ b/protobuf_for_node.h
@@ -17,6 +17,11 @@
 #include <google/protobuf/stubs/common.h>
 
 namespace protobuf_for_node {
+  const int64_t MAX_SAFE_INTEGER = 9007199254740991;
+  const int64_t MIN_SAFE_INTEGER = -9007199254740991;
+  const uint64_t MAX_SAFE_UNSIGNED_INTEGER = 9007199254740991;
+  const uint64_t MIN_SAFE_UNSIGNED_INTEGER = 0;
+
   v8::Local<v8::Function> SchemaConstructor();
 
   // Exports a JS object under "name" in "target" which forwards method calls to

--- a/test/unittest.js
+++ b/test/unittest.js
@@ -6,18 +6,27 @@ var assert = require('assert'),
 /* hack to make the tests pass with node v0.3.0's new Buffer model */
 /* copied from http://github.com/bnoordhuis/node-iconv/blob/master/test.js */
 assert.bufferEqual = function(a, b, c) {
+  assert.equal(a.length, b.length, c);
+  for (var i = 0; i < a.length; i++) {
+    assert.equal(a[i], b[i], c);
+  }
 	assert.equal(
 		a.inspect().replace(/^<SlowBuffer/, '<Buffer'),
 		b.inspect().replace(/^<SlowBuffer/, '<Buffer'),
                 c);
 };
 
+var MAX_SAFE_INTEGER = Math.pow(2, 53) - 1;
+var MIN_SAFE_INTEGER = -MAX_SAFE_INTEGER;
+
 var T = new Schema(read('test/unittest.desc'))['protobuf_unittest.TestAllTypes'];
 assert.ok(T, 'type in schema');
 var golden = read('test/golden_message');
 var message = T.parse(golden);
 assert.ok(message, 'parses message');  // currently rather crashes
-
+// console.log(message)
+assert.strictEqual(message.optionalInt64, 102);
+assert.strictEqual(message.optionalUint64, 104);
 assert.bufferEqual(T.serialize(message), golden, 'roundtrip');
 
 message.ignored = 42;
@@ -26,6 +35,53 @@ assert.bufferEqual(T.serialize(message), golden, 'ignored field');
 assert.throws(function() {
   T.parse(new Buffer('invalid'));
 }, Error, 'Should not parse');
+
+var safeIntegers = [
+  MIN_SAFE_INTEGER, MIN_SAFE_INTEGER + 1, MIN_SAFE_INTEGER + 2,
+  -100, -1, 0, 1, 100, 500, 1000, 10000, 1000000,
+  MAX_SAFE_INTEGER - 2, MAX_SAFE_INTEGER - 1, MAX_SAFE_INTEGER
+];
+var unsafeIntegers = [
+  MIN_SAFE_INTEGER - 1, MIN_SAFE_INTEGER - 2,
+  MAX_SAFE_INTEGER + 1, MAX_SAFE_INTEGER + 2,
+  '9007199254740992123'
+];
+
+safeIntegers.forEach(function (v) {
+  assert.strictEqual(T.parse(
+    T.serialize({
+      optionalInt64: v
+    })
+  ).optionalInt64, v);
+
+  if (v < 0) {
+    return;
+  }
+
+  assert.strictEqual(T.parse(
+    T.serialize({
+      optionalUint64: v
+    })
+  ).optionalUint64, v);
+});
+
+unsafeIntegers.forEach(function (v) {
+  assert.strictEqual(T.parse(
+    T.serialize({
+      optionalInt64: v
+    })
+  ).optionalInt64, String(v));
+
+  if (v < 0 && typeof v !== 'string') {
+    return;
+  }
+
+  assert.strictEqual(T.parse(
+    T.serialize({
+      optionalUint64: v
+    })
+  ).optionalUint64, String(v));
+});
 
 assert.strictEqual(T.parse(
   T.serialize({


### PR DESCRIPTION
In 90% cases, the (u)int64 numbers are small integer. I think we should use Number to present them when they are safe in Javascript.
